### PR TITLE
feat: block edits while data is under review

### DIFF
--- a/supabase/functions/_shared/update_data_review_guard.ts
+++ b/supabase/functions/_shared/update_data_review_guard.ts
@@ -1,0 +1,24 @@
+type UpdateDataPayload = Record<string, unknown> | null | undefined;
+
+const getDefinedEntries = (data: UpdateDataPayload) => {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return [];
+  }
+
+  return Object.entries(data).filter(([, value]) => value !== undefined);
+};
+
+export const isStateCodeOnlyUpdate = (data: UpdateDataPayload) => {
+  const entries = getDefinedEntries(data);
+
+  return (
+    entries.length === 1 && entries[0]?.[0] === 'state_code' && typeof entries[0]?.[1] === 'number'
+  );
+};
+
+export const canNonReviewAdminUpdateUnderReviewData = (
+  oldStateCode: number | undefined,
+  data: UpdateDataPayload,
+) => {
+  return oldStateCode === 20 && isStateCodeOnlyUpdate(data);
+};

--- a/supabase/functions/update_data/index.ts
+++ b/supabase/functions/update_data/index.ts
@@ -11,6 +11,7 @@ import getDataDetail from '../_shared/get_data.ts';
 import getUserRole from '../_shared/get_user_role.ts';
 import { supabaseClient } from '../_shared/supabase_client.ts';
 import updateData from '../_shared/update_data.ts';
+import { canNonReviewAdminUpdateUnderReviewData } from '../_shared/update_data_review_guard.ts';
 
 Deno.serve(async (req) => {
   const jsonResponse = (body: Record<string, unknown>, status: number) =>
@@ -65,7 +66,16 @@ Deno.serve(async (req) => {
   if (!isReviewAdmin && !isOwner) {
     return new Response('Forbidden', { status: 403 });
   }
-  if (!isReviewAdmin && oldData?.stateCode >= 20 && oldData?.stateCode < 100) {
+  const isAllowedUnderReviewStateTransition = canNonReviewAdminUpdateUnderReviewData(
+    oldData?.stateCode,
+    data,
+  );
+  if (
+    !isReviewAdmin &&
+    oldData?.stateCode >= 20 &&
+    oldData?.stateCode < 100 &&
+    !isAllowedUnderReviewStateTransition
+  ) {
     return jsonResponse(
       {
         code: 'DATA_UNDER_REVIEW',

--- a/supabase/functions/update_data/index.ts
+++ b/supabase/functions/update_data/index.ts
@@ -13,6 +13,12 @@ import { supabaseClient } from '../_shared/supabase_client.ts';
 import updateData from '../_shared/update_data.ts';
 
 Deno.serve(async (req) => {
+  const jsonResponse = (body: Record<string, unknown>, status: number) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    });
+
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }
@@ -43,6 +49,8 @@ Deno.serve(async (req) => {
     supabaseClient,
   );
   const { data: userRole } = await getUserRole(user.id!, supabaseClient);
+  const isReviewAdmin = Boolean(userRole?.find((item: any) => item.role === 'review-admin'));
+  const isOwner = oldData?.userId === user.id;
 
   if (!oldDataSuccess) {
     return new Response('Data Not Found', { status: 404 });
@@ -54,8 +62,19 @@ Deno.serve(async (req) => {
       return new Response('State Code Not Allowed', { status: 403 });
     }
   }
-  if (!userRole?.find((item: any) => item.role === 'review-admin') && oldData?.userId !== user.id) {
+  if (!isReviewAdmin && !isOwner) {
     return new Response('Forbidden', { status: 403 });
+  }
+  if (!isReviewAdmin && oldData?.stateCode >= 20 && oldData?.stateCode < 100) {
+    return jsonResponse(
+      {
+        code: 'DATA_UNDER_REVIEW',
+        message: 'Data is under review and cannot be modified',
+        review_state_code: oldData?.stateCode,
+        state_code: 20,
+      },
+      403,
+    );
   }
 
   const updateResult = await updateData(id, version, table, data, supabaseClient);

--- a/test/update_data_review_guard_test.ts
+++ b/test/update_data_review_guard_test.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from 'jsr:@std/assert';
+
+import {
+  canNonReviewAdminUpdateUnderReviewData,
+  isStateCodeOnlyUpdate,
+} from '../supabase/functions/_shared/update_data_review_guard.ts';
+
+Deno.test('isStateCodeOnlyUpdate only accepts pure state_code payloads', () => {
+  assertEquals(isStateCodeOnlyUpdate({ state_code: 0 }), true);
+  assertEquals(isStateCodeOnlyUpdate({ state_code: 100 }), true);
+  assertEquals(isStateCodeOnlyUpdate({ state_code: 0, json: {} }), false);
+  assertEquals(isStateCodeOnlyUpdate({ state_code: 100, reviews: [] }), false);
+  assertEquals(isStateCodeOnlyUpdate({ reviews: [] }), false);
+  assertEquals(isStateCodeOnlyUpdate(undefined), false);
+});
+
+Deno.test('canNonReviewAdminUpdateUnderReviewData only allows state transitions from 20', () => {
+  assertEquals(canNonReviewAdminUpdateUnderReviewData(20, { state_code: 0 }), true);
+  assertEquals(canNonReviewAdminUpdateUnderReviewData(20, { state_code: 100 }), true);
+  assertEquals(
+    canNonReviewAdminUpdateUnderReviewData(20, { state_code: 0, json: { foo: 'bar' } }),
+    false,
+  );
+  assertEquals(canNonReviewAdminUpdateUnderReviewData(30, { state_code: 0 }), false);
+  assertEquals(canNonReviewAdminUpdateUnderReviewData(20, { reviews: [] }), false);
+});


### PR DESCRIPTION
Closes Neo9281/tiangong-lca-edge-functions#2

## Summary
- Reject non-review update_data mutations while the dataset stateCode is between 20 and 99.
- Return an explicit DATA_UNDER_REVIEW error while preserving review-admin update paths.

## Validation
- npm run lint

## Workspace Integration
- Requires a later lca-workspace submodule bump after merge.